### PR TITLE
Update README about `Config/setting.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ DATABASES = {
     "default": {
         "TYPE": "SSDB",        # 如果使用SSDB或redis数据库，均配置为SSDB
         "HOST": "127.0.0.1",   # db host
-        "PORT": 8888,          # db port
+        "PORT": 8888,          # db port，例如SSDB通常使用8888，redis通常默认使用6379
         "NAME": "proxy",       # 默认配置
         "PASSWORD": ""         # db password
 


### PR DESCRIPTION
修改了配置文件的示例内容，对新手更友好。新手（我）一开始用的时候，只修改了其他配置，我用的是redis，不知道还要把端口号改成redis的端口。然后程序爬下来的IP要存进数据库的时候每次都fail，找了很久原因，才试出来是因为这个。