### PR TITLE
升级flask1.1后，调用/get_all/失败

### DIFF
--- a/Manager/ProxyManager.py
+++ b/Manager/ProxyManager.py
@@ -88,7 +88,7 @@ class ProxyManager(object):
         self.db.changeTable(self.useful_proxy_queue)
         item_dict = self.db.getAll()
         if EnvUtil.PY3:
-            return list(item_dict.keys()) if item_dict else list()
+            return str(list(item_dict.keys())) if item_dict else None
         return item_dict.keys() if item_dict else list()
 
     def getNumber(self):


### PR DESCRIPTION
报错原因：
TypeError: The view function did not return a valid response. The return type must be a string, dict, tuple, Response instance, or WSGI callable, but it was a list.
