### PR TITLE
update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     links:
       - proxy_redis
     environment:
-      db_type: SSDB
-      ssdb_host: proxy_redis
-      ssdb_port: 6379
+      db_type: REDIS
+      db_host: proxy_redis
+      db_port: 6379
   proxy_redis:
     image: "redis"


### PR DESCRIPTION
# Docker Compose Error!

Error Message:
```console
****************************************************************
*** ______  ********************* ______ *********** _  ********
*** | ___ \_ ******************** | ___ \ ********* | | ********
*** | |_/ / \__ __   __  _ __   _ | |_/ /___ * ___  | | ********
*** |  __/|  _// _ \ \ \/ /| | | ||  __// _ \ / _ \ | | ********
*** | |   | | | (_) | >  < \ |_| || |  | (_) | (_) || |___  ****
*** \_|   |_|  \___/ /_/\_\ \__  |\_|   \___/ \___/ \_____/ ****
****                       __ / /                          *****
************************* /___ / *******************************
*************************       ********************************
****************************************************************


****************************************************************
*** ______  ********************* ______ *********** _  ********
*** | ___ \_ ******************** | ___ \ ********* | | ********
*** | |_/ / \__ __   __  _ __   _ | |_/ /___ * ___  | | ********
*** |  __/|  _// _ \ \ \/ /| | | ||  __// _ \ / _ \ | | ********
*** | |   | | | (_) | >  < \ |_| || |  | (_) | (_) || |___  ****
*** \_|   |_|  \___/ /_/\_\ \__  |\_|   \___/ \___/ \_____/ ****
****                       __ / /                          *****
************************* /___ / *******************************
*************************       ********************************
****************************************************************

2019-10-02 18:42:40,549 ProxyScheduler.py[line:33] INFO start fetch proxy
2019-10-02 18:42:40,555 ProxyManager.py[line:44] INFO ProxyFetch : start
2019-10-02 18:42:40,556 ProxyManager.py[line:46] INFO ProxyFetch - freeProxy01: start
[2019-10-02 18:42:40 +0800] [6] [INFO] Starting gunicorn 19.9.0
[2019-10-02 18:42:40 +0800] [6] [INFO] Listening at: http://0.0.0.0:5010 (6)
[2019-10-02 18:42:40 +0800] [6] [INFO] Using worker: sync
[2019-10-02 18:42:40 +0800] [14] [INFO] Booting worker with pid: 14
[2019-10-02 18:42:40 +0800] [15] [INFO] Booting worker with pid: 15
[2019-10-02 18:42:40 +0800] [16] [INFO] Booting worker with pid: 16
[2019-10-02 18:42:40 +0800] [17] [INFO] Booting worker with pid: 17
2019-10-02 18:42:41,331 ProxyManager.py[line:61] INFO ProxyFetch - freeProxy01: 218.240.53.53:8090   success
2019-10-02 18:42:41,332 ProxyManager.py[line:65] ERROR ProxyFetch - freeProxy01: error
2019-10-02 18:42:41,332 ProxyManager.py[line:66] ERROR Error 111 connecting to 127.0.0.1:8080. Connection refused.
2019-10-02 18:42:41,332 ProxyManager.py[line:46] INFO ProxyFetch - freeProxy02: start
2019-10-02 18:42:42,073 ProxyManager.py[line:46] INFO ProxyFetch - freeProxy03: start
2019-10-02 18:43:03,875 ProxyManager.py[line:65] ERROR ProxyFetch - freeProxy03: error
2019-10-02 18:43:03,876 ProxyManager.py[line:66] ERROR can only parse strings
2019-10-02 18:43:03,876 ProxyManager.py[line:46] INFO ProxyFetch - freeProxy04: start
2019-10-02 18:43:04,494 ProxyManager.py[line:61] INFO ProxyFetch - freeProxy04: 218.240.53.53:8090   success
2019-10-02 18:43:04,495 ProxyManager.py[line:65] ERROR ProxyFetch - freeProxy04: error
2019-10-02 18:43:04,496 ProxyManager.py[line:66] ERROR Error 111 connecting to 127.0.0.1:8080. Connection refused.
2019-10-02 18:43:04,496 ProxyManager.py[line:46] INFO ProxyFetch - freeProxy05: start
2019-10-02 18:43:06,490 ProxyManager.py[line:61] INFO ProxyFetch - freeProxy05: 1.198.73.34:9999     success
2019-10-02 18:43:06,491 ProxyManager.py[line:65] ERROR ProxyFetch - freeProxy05: error
2019-10-02 18:43:06,491 ProxyManager.py[line:66] ERROR Error 111 connecting to 127.0.0.1:8080. Connection refused.
2019-10-02 18:43:06,492 ProxyManager.py[line:46] INFO ProxyFetch - freeProxy06: start
2019-10-02 18:43:26,747 ProxyManager.py[line:65] ERROR ProxyFetch - freeProxy06: error
2019-10-02 18:43:26,748 ProxyManager.py[line:66] ERROR can only parse strings
2019-10-02 18:43:26,749 ProxyManager.py[line:46] INFO ProxyFetch - freeProxy07: start
2019-10-02 18:43:28,528 ProxyManager.py[line:61] INFO ProxyFetch - freeProxy07: 183.166.163.22:9999  success
2019-10-02 18:43:28,529 ProxyManager.py[line:65] ERROR ProxyFetch - freeProxy07: error
2019-10-02 18:43:28,530 ProxyManager.py[line:66] ERROR Error 111 connecting to 127.0.0.1:8080. Connection refused.
2019-10-02 18:43:28,530 ProxyManager.py[line:46] INFO ProxyFetch - freeProxy08: start
2019-10-02 18:43:30,201 ProxyManager.py[line:61] INFO ProxyFetch - freeProxy08: 118.187.58.34:53281  success
2019-10-02 18:43:30,202 ProxyManager.py[line:65] ERROR ProxyFetch - freeProxy08: error
2019-10-02 18:43:30,203 ProxyManager.py[line:66] ERROR Error 111 connecting to 127.0.0.1:8080. Connection refused.
2019-10-02 18:43:30,203 ProxyManager.py[line:46] INFO ProxyFetch - freeProxy09: start
2019-10-02 18:43:30,729 ProxyManager.py[line:61] INFO ProxyFetch - freeProxy09: 119.57.108.53:53281  success
2019-10-02 18:43:30,731 ProxyManager.py[line:65] ERROR ProxyFetch - freeProxy09: error
2019-10-02 18:43:30,732 ProxyManager.py[line:66] ERROR Error 111 connecting to 127.0.0.1:8080. Connection refused.
2019-10-02 18:43:30,733 ProxyScheduler.py[line:35] INFO finish fetch proxy
('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
HTTPSConnectionPool(host='proxy.coderbusy.com', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fa8659e1128>: Failed to establish a new connection: [Errno -2] Name or service not known',))
HTTPSConnectionPool(host='proxy.coderbusy.com', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fa8659e1b00>: Failed to establish a new connection: [Errno -2] Name or service not known',))
HTTPSConnectionPool(host='proxy.coderbusy.com', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fa8659e11d0>: Failed to establish a new connection: [Errno -2] Name or service not known',))
HTTPSConnectionPool(host='proxy.coderbusy.com', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fa8659e1e48>: Failed to establish a new connection: [Errno -2] Name or service not known',))
HTTPSConnectionPool(host='proxy.coderbusy.com', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fa8659e1128>: Failed to establish a new connection: [Errno -2] Name or service not known',))
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 538, in connect
    sock = self._connect()
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 595, in _connect
    raise err
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 583, in _connect
    sock.connect(socket_address)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "proxyPool.py", line 52, in <module>
    cli()
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "proxyPool.py", line 38, in schedule
    runScheduler()
  File "../Schedule/ProxyScheduler.py", line 48, in runScheduler
    rawProxyScheduler()
  File "../Schedule/ProxyScheduler.py", line 40, in rawProxyScheduler
    doRawProxyCheck()
  File "../Schedule/RawProxyCheck.py", line 65, in doRawProxyCheck
    for _proxy in pm.db.getAll():
  File "../DB/DbClient.py", line 102, in getAll
    return self.client.getAll()
  File "/usr/src/app/DB/SsdbClient.py", line 109, in getAll
    item_dict = self.__conn.hgetall(self.name)
  File "/usr/local/lib/python3.6/site-packages/redis/client.py", line 2717, in hgetall
    return self.execute_command('HGETALL', name)
  File "/usr/local/lib/python3.6/site-packages/redis/client.py", line 836, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 1222, in get_connection
    connection.connect()
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 543, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 111 connecting to 127.0.0.1:8080. Connection refused.
```

## Reproduce: 

```bash
git clone  https://github.com/jhao104/proxy_pool.git
cd proxy_pool
docker-compose up -d
docker logs --follow proxypool_proxy_pool_1
```

## Analysis:

Database Configuration Error! The `redis` server maps to the port `6379` instead of `8080`. In addition, the python settings parser does not recognize `ssdb_host` and `ssdb_port`; instead, it recognizes `db_host` and `db_port`. 

## Suggestion:

In `docker-compose.yml` lines 10-12

```diff
-      db_type: SSDB
-      ssdb_host: proxy_redis
-      ssdb_port: 6379
+      db_type: REDIS
+      db_host: proxy_redis
+      db_port: 6379
```
