### PR TITLE
MOD:fix default db_port to int and add a type check for env

### DIFF
--- a/Config/ConfigGetter.py
+++ b/Config/ConfigGetter.py
@@ -39,7 +39,7 @@ class ConfigGetter(object):
 
     @LazyProperty
     def db_port(self):
-        return DATABASES.get("default", {}).get("PORT", 8080)
+        return DATABASES.get("default", {}).get("PORT", 8888)
 
     @LazyProperty
     def db_password(self):

--- a/Config/setting.py
+++ b/Config/setting.py
@@ -35,7 +35,7 @@ PY3 = sys.version_info >= (3,)
 
 DB_TYPE = getenv('db_type', 'SSDB').upper()
 DB_HOST = getenv('db_host', '127.0.0.1')
-DB_PORT = getenv('db_port', '8080')
+DB_PORT = getenv('db_port', 8888)
 DB_PASSWORD = getenv('db_password', '')
 
 
@@ -79,8 +79,8 @@ def checkConfig():
     if DB_TYPE not in ["SSDB", "REDIS"]:
         raise ConfigError('db_type Do not support: %s, must SSDB/REDIS .' % DB_TYPE)
 
-    if not DB_PORT.isdigit():
-        raise ConfigError('db_port must be digit, not %s' % DB_PORT)
+    if type(DB_PORT) == str and not DB_PORT.isdigit():
+        raise ConfigError('if db_port is string, it must be digit, not %s' % DB_PORT)
 
     from ProxyGetter import getFreeProxy
     illegal_getter = list(filter(lambda key: not hasattr(getFreeProxy.GetFreeProxy, key), PROXY_GETTER))


### PR DESCRIPTION
无论是在readme.md里还是在ConfigGetter.py里,db_port的配置都是int类型的

1. readme.md
```
配置Config/setting.py:
# Config/setting.py 为项目配置文件

# 配置DB     
DATABASES = {
    "default": {
        "TYPE": "SSDB",        # 目前支持SSDB或REDIS数据库
        "HOST": "127.0.0.1",   # db host
        "PORT": 8888,          # db port，例如SSDB通常使用8888，REDIS通常默认使用6379
        "NAME": "proxy",       # 默认配置
        "PASSWORD": ""         # db password

    }
}

```

2. ConfigGetter.py
https://github.com/jhao104/proxy_pool/blob/5349289ff3e5679da7ceb62765ab4212ea40fdfe/Config/ConfigGetter.py#L40-L42

但在settings.py里，db_port却是str类型的
https://github.com/jhao104/proxy_pool/blob/5349289ff3e5679da7ceb62765ab4212ea40fdfe/Config/setting.py#L34-L39

并且会对db_port配置进行是否是数字字符串进行检测
https://github.com/jhao104/proxy_pool/blob/5349289ff3e5679da7ceb62765ab4212ea40fdfe/Config/setting.py#L82-L83

原因是优先读环境变量`DB_PORT = getenv('db_port', '8080')`

这里是非常容易误导人的，特别是readme文档和ConfigGetter.py代码与实际配置不符。如果按照readme文档里操作，在settings里将db_port设置为int类型，比如8888，就会得到一个int类型不能.isdigit()的错误.

所以个人认为这里还是应该按照readme的配置方式配置为int型，因为这里本来就是端口变量，端口是int型比较符合正常理解。同时在checkConfig()中添加判断，只有db_port是str型(既读取环境变量时)，才去判断这个字符串是否是数字字符串。这样比较合理。

另外，ConfigGetter.py里的这样的get不到取默认值的操作是否意义?因为只要不把整个settings.py里的DATABASES字段完全修改,这里都读不到这个默认值。
https://github.com/jhao104/proxy_pool/blob/5349289ff3e5679da7ceb62765ab4212ea40fdfe/Config/ConfigGetter.py#L40-L42