### PR TITLE
ADD:add the helm chart for proxy_pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ docker run --env db_type=REDIS --env db_host=127.0.0.1 --env db_port=6379 --env 
 
 ```
 
+### helm chart(更多使用参数请参考[helm chart文档](./helm/README.md)):
+```bash
+git clone git@github.com:jhao104/proxy_pool.git
+
+cd proxy_pool
+
+helm install proxy-pool ./helm/proxy-pool --set proxyPoolConfig.dbHost=192.168.1.100 --set proxyPoolConfig.dbPassword=calmkart
+
+kubectl port-forward svc/proxy-pool 8080:80
+
+# Wait a few minutes
+curl localhost:8080/get/
+# result: xxx.xxx.xxx.xxx:xxxx
+
+curl localhost:8080/get_all/
+```
+
 
 ### 使用
 

--- a/doc/introduce.md
+++ b/doc/introduce.md
@@ -112,7 +112,7 @@ pip install -r requirements.txt
 ```
 
 docker:
-```
+```bash
 git clone git@github.com:jhao104/proxy_pool.git
 
 cd proxy_pool
@@ -127,6 +127,24 @@ curl localhost:5010/get/
 
 curl localhost:5010/get_all/
 ```
+
+helm chart(更多使用参数请参考[helm chart文档](../helm/README.md)):
+```bash
+git clone git@github.com:jhao104/proxy_pool.git
+
+cd proxy_pool
+
+helm install proxy-pool ./helm/proxy-pool 
+
+kubectl port-forward svc/proxy-pool 8080:80
+
+# Wait a few minutes
+curl localhost:8080/get/
+# result: xxx.xxx.xxx.xxx:xxxx
+
+curl localhost:8080/get_all/
+```
+
 
 ### 5、使用
 　　定时任务启动后，会通过GetFreeProxy中的方法抓取代理存入数据库并验证。此后默认每10分钟会重复执行一次。定时任务启动大概一两分钟后，便可在[SSDB](https://github.com/jhao104/SSDBAdmin)中看到刷新出来的可用的代理：

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,47 @@
+# proxy-pool
+
+
+## helm chart安装方式:
+```shell
+helm install proxy-pool ./proxy-pool
+```
+> 如果要配合其他可用参数,可以自行设置,参数列表见文末,例如:
+> 
+> `helm install proxy-pool ./proxy-pool --set proxyPoolConfig.dbHost=192.168.1.100 --set proxyPoolConfig.dbPassword=calmkart`
+
+运行后将看到输出并创建k8s api对象(deployment&&service):
+```shell
+➜  helm ✗ helm install proxy-pool ./proxy-pool
+NAME: proxy-pool
+LAST DEPLOYED: 2019-11-11 16:43:55.381296 +0800 CST m=+0.398530920
+NAMESPACE: default
+STATUS: deployed
+
+NOTES:
+1. Get the application URL by running these commands:
+  export POD_NAME=$(kubectl get pods -l "app=proxy-pool,release=proxy-pool" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+```
+
+我们可以通过port-forward或者ingress访问服务
+
+>`kubectl port-forward svc/proxy-pool 8080:80`
+- 访问地址 `http://0.0.0.0:8080/`
+
+>如果我们打开ingress功能,则将proxy-pool.calmkart.com的域名解析切换到ingress地址即可访问(修改hosts或dns皆可)
+- 访问地址: `http://proxy-pool.calmkart.com/`
+
+### 3. 其他备注
+
+#### 可用参数
+| Parameter | Description | Default |
+| ----- | ----------- | ------ |
+| `pullPolicy` | docker镜像拉取策略(因为tag使用的是latest,所以推荐使用默认的Always,调试或特殊情况可修改) |`Always`| 
+| `proxyPoolConfig.dbType` | proxy-pool使用的数据库类型 |`"REDIS"`|
+| `proxyPoolConfig.dbHost` | proxy-pool使用的数据库ip |`"127.0.0.1"`|
+| `proxyPoolConfig.dbPort` | proxy-pool使用的数据库端口 |`6379`|
+| `proxyPoolConfig.dbPassword` | proxy-pool使用的数据库密码 |`""`|
+| `proxyPoolConfig.servePort` | proxy-pool提供服务的端口 |`5010`|
+| `ingress.enable` | 是否打开ingress |`false`|
+| `ingress.hosts` | ingress域名 | `['proxy-pool.calmkart.com']` | 

--- a/helm/proxy-pool/.helmignore
+++ b/helm/proxy-pool/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/proxy-pool/Chart.yaml
+++ b/helm/proxy-pool/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+name: proxy-pool
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: latest

--- a/helm/proxy-pool/templates/NOTES.txt
+++ b/helm/proxy-pool/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "proxy-pool.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "proxy-pool.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc {{ template "proxy-pool.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods -l "app.kubernetes.io/name={{ template "proxy-pool.name" . }},app.kubernetes.io/instance={{ proxy-pool.name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm/proxy-pool/templates/_helpers.tpl
+++ b/helm/proxy-pool/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "proxy-pool.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "proxy-pool.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "proxy-pool.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "proxy-pool.labels" -}}
+app.kubernetes.io/name: {{ include "proxy-pool.name" . }}
+helm.sh/chart: {{ include "proxy-pool.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/helm/proxy-pool/templates/deployment.yaml
+++ b/helm/proxy-pool/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "proxy-pool.fullname" . }}
+  labels:
+{{ include "proxy-pool.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "proxy-pool.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "proxy-pool.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: db_type
+              value: "{{ .Values.proxyPoolConfig.dbType }}"
+            - name: db_host
+              value: "{{ .Values.proxyPoolConfig.dbHost }}"
+            - name: db_port
+              value: "{{ .Values.proxyPoolConfig.dbPort }}"
+            - name: db_password
+              value: "{{ .Values.proxyPoolConfig.dbPassword }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.proxyPoolConfig.servePort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm/proxy-pool/templates/ingress.yaml
+++ b/helm/proxy-pool/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "proxy-pool.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "proxy-pool.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/helm/proxy-pool/templates/service.yaml
+++ b/helm/proxy-pool/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "proxy-pool.fullname" . }}
+  labels:
+{{ include "proxy-pool.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "proxy-pool.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/proxy-pool/values.yaml
+++ b/helm/proxy-pool/values.yaml
@@ -1,0 +1,53 @@
+# Default values for proxy-pool.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: jhao104/proxy_pool
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+  path: /
+  hosts:
+    - proxy-pool.calmkart.com
+  tls: []
+  #  - secretName: proxy-pool-tls
+  #    hosts:
+  #      - proxy-pool.calmkart.com
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# we can set the proxy_pool config here
+proxyPoolConfig:
+  dbType: REDIS
+  dbHost: 127.0.0.1
+  dbPort: 6379
+  dbPassword: ""
+  servePort: 5010


### PR DESCRIPTION
增加helm chart的安装方式
能够实现便捷的将proxy_pool服务部署至kubernetes集群中.如
`helm install proxy-pool ./helm/proxy-pool`
即可完成部署.详情见pr中的各readme.md.

test in k8s v1.16.0