### PR TITLE
Support proxy types other than http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 *.pyc
 *.log
+.venv

--- a/Api/ProxyApi.py
+++ b/Api/ProxyApi.py
@@ -64,6 +64,12 @@ def get_socks():
     return proxy.info_json if proxy else {"code": 0, "src": "no proxy"}
 
 
+@app.route('/get_http/')
+def get_http():
+    proxy = ProxyManager().get_http()
+    return proxy.info_json if proxy else {"code": 0, "src": "no proxy"}
+
+
 @app.route('/refresh/')
 def refresh():
     # TODO refresh会有守护程序定时执行，由api直接调用性能较差，暂不使用

--- a/Api/ProxyApi.py
+++ b/Api/ProxyApi.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # !/usr/bin/env python
+from Manager.ProxyManager import ProxyManager
+from Config.ConfigGetter import config
 """
 -------------------------------------------------
    File Name：     ProxyApi.py
@@ -21,8 +23,6 @@ from flask import Flask, jsonify, request
 
 sys.path.append('../')
 
-from Config.ConfigGetter import config
-from Manager.ProxyManager import ProxyManager
 
 app = Flask(__name__)
 
@@ -58,6 +58,12 @@ def get():
     return proxy.info_json if proxy else {"code": 0, "src": "no proxy"}
 
 
+@app.route('/get_socks/')
+def get_socks():
+    proxy = ProxyManager().get_socks()
+    return proxy.info_json if proxy else {"code": 0, "src": "no proxy"}
+
+
 @app.route('/refresh/')
 def refresh():
     # TODO refresh会有守护程序定时执行，由api直接调用性能较差，暂不使用
@@ -88,7 +94,6 @@ def getStatus():
 if platform.system() != "Windows":
     import gunicorn.app.base
     from six import iteritems
-
 
     class StandaloneApplication(gunicorn.app.base.BaseApplication):
 

--- a/Config/setting.py
+++ b/Config/setting.py
@@ -55,16 +55,19 @@ DATABASES = {
 PROXY_GETTER = [
     "freeProxy01",
     # "freeProxy02",
-    "freeProxy03",
+    # "freeProxy03",
     "freeProxy04",
     "freeProxy05",
-    # "freeProxy06",
-    "freeProxy07",
+    "freeProxy06",
+    # "freeProxy07",
     # "freeProxy08",
     "freeProxy09",
-    "freeProxy13",
-    "freeProxy14",
-    "freeProxy14",
+    # "freeProxy14",
+    "freeProxy15",
+    "proxygather_com",
+    "proxy_list_download",
+    "spys_one",
+    "socks_proxy_net",
 ]
 
 """ API config http://127.0.0.1:5010 """
@@ -80,15 +83,19 @@ class ConfigError(BaseException):
 
 def checkConfig():
     if DB_TYPE not in ["SSDB", "REDIS"]:
-        raise ConfigError('db_type Do not support: %s, must SSDB/REDIS .' % DB_TYPE)
+        raise ConfigError(
+            'db_type Do not support: %s, must SSDB/REDIS .' % DB_TYPE)
 
     if type(DB_PORT) == str and not DB_PORT.isdigit():
-        raise ConfigError('if db_port is string, it must be digit, not %s' % DB_PORT)
+        raise ConfigError(
+            'if db_port is string, it must be digit, not %s' % DB_PORT)
 
     from ProxyGetter import getFreeProxy
-    illegal_getter = list(filter(lambda key: not hasattr(getFreeProxy.GetFreeProxy, key), PROXY_GETTER))
+    illegal_getter = list(filter(lambda key: not hasattr(
+        getFreeProxy.GetFreeProxy, key), PROXY_GETTER))
     if len(illegal_getter) > 0:
-        raise ConfigError("ProxyGetter: %s does not exists" % "/".join(illegal_getter))
+        raise ConfigError("ProxyGetter: %s does not exists" %
+                          "/".join(illegal_getter))
 
 
 checkConfig()

--- a/Manager/ProxyManager.py
+++ b/Manager/ProxyManager.py
@@ -87,6 +87,24 @@ class ProxyManager(object):
 
         return None
 
+    def get_http(self):
+        """
+        return a http proxy
+        :return:
+        """
+        self.db.changeTable(self.useful_proxy_queue)
+        item_list = self.db.getAll()
+
+        if item_list:
+            for _ in item_list:
+                random_choice = random.choice(item_list)
+                proxy_type = json.loads(random_choice)['proxy'].split("://")[0]
+
+                if proxy_type == 'http':
+                    return Proxy.newProxyFromJson(random_choice)
+
+        return None
+
     def get_socks(self):
         """
         return a useful socks proxy

--- a/ProxyGetter/getFreeProxy.py
+++ b/ProxyGetter/getFreeProxy.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 # !/usr/bin/env python
+from bs4 import BeautifulSoup
+from requests_html import HTMLSession
+from Util.utilFunction import getHtmlTree
+from Util.WebRequest import WebRequest
 """
 -------------------------------------------------
    File Name：     GetFreeProxy.py
@@ -18,8 +22,6 @@ from time import sleep
 
 sys.path.append('..')
 
-from Util.WebRequest import WebRequest
-from Util.utilFunction import getHtmlTree
 
 # for debug to disable insecureWarning
 requests.packages.urllib3.disable_warnings()
@@ -56,7 +58,7 @@ class GetFreeProxy(object):
                         port_sum *= 10
                         port_sum += key.index(c)
                     port = port_sum >> 3
-                    yield '{}:{}'.format(ip, port)
+                    yield 'http://{}:{}'.format(ip, port)
                 except Exception as e:
                     print(e)
 
@@ -85,8 +87,10 @@ class GetFreeProxy(object):
             src = session.get("http://www.66ip.cn/", headers=headers).text
             src = src.split("</script>")[0] + '}'
             src = src.replace("<script>", "function test() {")
-            src = src.replace("while(z++)try{eval(", ';var num=10;while(z++)try{var tmp=')
-            src = src.replace(");break}", ";num--;if(tmp.search('cookie') != -1 | num<0){return tmp}}")
+            src = src.replace(
+                "while(z++)try{eval(", ';var num=10;while(z++)try{var tmp=')
+            src = src.replace(
+                ");break}", ";num--;if(tmp.search('cookie') != -1 | num<0){return tmp}}")
             ctx = execjs.compile(src)
             src = ctx.call("test")
             src = src[src.find("document.cookie="): src.find("};if((")]
@@ -100,10 +104,12 @@ class GetFreeProxy(object):
 
         for url in urls:
             try:
-                html = session.get(url.format(count), cookies={"__jsl_clearance": js_cookie}, headers=headers).text
-                ips = re.findall(r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}", html)
+                html = session.get(url.format(count), cookies={
+                                   "__jsl_clearance": js_cookie}, headers=headers).text
+                ips = re.findall(
+                    r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}", html)
                 for ip in ips:
-                    yield ip.strip()
+                    yield 'http://'+ip.strip()
             except Exception as e:
                 print(e)
                 pass
@@ -122,10 +128,11 @@ class GetFreeProxy(object):
             for i in range(1, page_count + 1):
                 page_url = each_url + str(i)
                 tree = getHtmlTree(page_url)
-                proxy_list = tree.xpath('.//table[@id="ip_list"]//tr[position()>1]')
+                proxy_list = tree.xpath(
+                    './/table[@id="ip_list"]//tr[position()>1]')
                 for proxy in proxy_list:
                     try:
-                        yield ':'.join(proxy.xpath('./td/text()')[0:2])
+                        yield 'http://'+':'.join(proxy.xpath('./td/text()')[0:2])
                     except Exception as e:
                         pass
 
@@ -162,7 +169,7 @@ class GetFreeProxy(object):
                     port += (ord(_) - ord('A'))
                 port /= 8
 
-                yield '{}:{}'.format(ip_addr, int(port))
+                yield 'http://{}:{}'.format(ip_addr, int(port))
             except Exception as e:
                 pass
 
@@ -180,7 +187,7 @@ class GetFreeProxy(object):
             proxy_list = tree.xpath('.//table//tr')
             sleep(1)  # 必须sleep 不然第二条请求不到数据
             for tr in proxy_list[1:]:
-                yield ':'.join(tr.xpath('./td/text()')[0:2])
+                yield 'http://'+':'.join(tr.xpath('./td/text()')[0:2])
 
     @staticmethod
     def freeProxy06():
@@ -193,7 +200,7 @@ class GetFreeProxy(object):
             tree = getHtmlTree(url)
             proxy_list = tree.xpath('.//table//tr')
             for tr in proxy_list[1:]:
-                yield ':'.join(tr.xpath('./td/text()')[0:2])
+                yield 'http://'+':'.join(tr.xpath('./td/text()')[0:2])
 
     @staticmethod
     def freeProxy07():
@@ -206,9 +213,10 @@ class GetFreeProxy(object):
         request = WebRequest()
         for url in urls:
             r = request.get(url, timeout=10)
-            proxies = re.findall(r'<td>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})</td>[\s\S]*?<td>(\d+)</td>', r.text)
+            proxies = re.findall(
+                r'<td>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})</td>[\s\S]*?<td>(\d+)</td>', r.text)
             for proxy in proxies:
-                yield ":".join(proxy)
+                yield 'http://' + ":".join(proxy)
 
     @staticmethod
     def freeProxy08():
@@ -228,7 +236,7 @@ class GetFreeProxy(object):
             proxies = re.findall(r'<td>\s*?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s*?</td>[\s\S]*?<td>\s*?(\d+)\s*?</td>',
                                  r.text)
             for proxy in proxies:
-                yield ":".join(proxy)
+                yield "http://"+":".join(proxy)
 
     @staticmethod
     def freeProxy09(page_count=1):
@@ -243,7 +251,7 @@ class GetFreeProxy(object):
             for index, tr in enumerate(html_tree.xpath("//table//tr")):
                 if index == 0:
                     continue
-                yield ":".join(tr.xpath("./td/text()")[0:2]).strip()
+                yield 'http://'+":".join(tr.xpath("./td/text()")[0:2]).strip()
 
     # @staticmethod
     # def freeProxy10():
@@ -301,7 +309,7 @@ class GetFreeProxy(object):
                 r'<td.*?>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})</td>[\s\S]*?<td.*?>(\d+)</td>',
                 r.text)
             for proxy in proxies:
-                yield ':'.join(proxy)
+                yield 'http://'+':'.join(proxy)
 
     @staticmethod
     def freeProxy14(max_page=2):
@@ -320,7 +328,7 @@ class GetFreeProxy(object):
                 r'<td.*?>[\s\S]*?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})[\s\S]*?</td>[\s\S]*?<td.*?>[\s\S]*?(\d+)[\s\S]*?</td>',
                 r.text)
             for proxy in proxies:
-                yield ':'.join(proxy)
+                yield 'http://'+':'.join(proxy)
 
     @staticmethod
     def freeProxy15():
@@ -331,9 +339,103 @@ class GetFreeProxy(object):
         request = WebRequest()
         for url in urls:
             r = request.get(url, timeout=10)
-            ips = re.findall(r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}", r.text)
+            ips = re.findall(
+                r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}", r.text)
             for ip in ips:
-                yield ip.strip()
+                yield "http://" + ip.strip()
+
+    @staticmethod
+    def socks_proxy_net():
+        url = "https://www.socks-proxy.net"
+
+        resp = requests.get(url)
+        soup = BeautifulSoup(resp.text, "html5lib")
+
+        tables = [
+            [
+                [td.get_text(strip=True) for td in tr.find_all('td')]
+                for tr in table.find_all('tr')
+            ]
+            for table in soup.find_all('table')
+        ]
+
+        if not tables:
+            return
+
+        for row in tables[0]:
+            try:
+                yield 'socks4://' + row[0] + ':' + row[1]
+            except BaseException:
+                continue
+
+    @staticmethod
+    def proxy_list_download():
+        urls = ["https://www.proxy-list.download/api/v1/get?type=socks4",
+                "https://www.proxy-list.download/api/v1/get?type=socks5"]
+        proxy_resp = ""
+        for url in urls:
+            resp = requests.get(url, timeout=10)
+            proxy_resp += resp.text
+        proxy_list = proxy_resp.split('\n')
+        for proxy in proxy_list:
+            yield "socks4://" + proxy
+
+    @staticmethod
+    def proxygather_com():
+        url = "https://proxygather.com/sockslist"
+        try:
+            session = HTMLSession()
+            resp = session.get(url, timeout=10)
+            resp.html.render()
+        except BaseException:
+            return
+        soup = BeautifulSoup(resp.html.html, "html5lib")
+
+        tables = [
+            [
+                [td.get_text(strip=True) for td in tr.find_all('td')]
+                for tr in table.find_all('tr')
+            ]
+            for table in soup.find_all('table')
+        ]
+
+        if not tables:
+            return
+
+        for row in tables[0]:
+            try:
+                ip = row[1].split(')')[-1]
+                port = row[2].split(')')[-1]
+                yield 'socks4://' + ip + ':' + port
+            except BaseException:
+                continue
+
+    @staticmethod
+    def spys_one():
+        url = "http://spys.one/en/socks-proxy-list/"
+        header = {
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.2 Safari/605.1.15'}
+        data = {
+            'xpp': '5',
+            'xf1': '4',
+            'xf2': '0',
+            'xf4': '0',
+            'xf5': '2'
+        }
+        try:
+            session = HTMLSession()
+            resp = session.post(url, headers=header, data=data, timeout=10)
+            resp.html.render()
+        except BaseException:
+            return
+
+        soup = BeautifulSoup(resp.html.html, "html5lib")
+
+        tds = soup.findAll('font', {'class': 'spy14'})
+        for td in tds:
+            script = td.find('script')
+            if script:
+                yield "socks4://" + td.contents[0]+':'+td.contents[-1]
 
 
 if __name__ == '__main__':

--- a/Util/utilFunction.py
+++ b/Util/utilFunction.py
@@ -36,6 +36,7 @@ def verifyProxyFormat(proxy):
     :return:
     """
     import re
+    proxy = proxy.split("://")[1]
     verify_regex = r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}"
     _proxy = re.findall(verify_regex, proxy)
     return True if len(_proxy) == 1 and _proxy[0] == proxy else False
@@ -84,12 +85,12 @@ def validUsefulProxy(proxy):
     """
     if isinstance(proxy, bytes):
         proxy = proxy.decode("utf8")
-    proxies = {"http": "http://{proxy}".format(proxy=proxy)}
+    proxies = dict(http=f'{proxy}', https=f'{proxy}')
     try:
-        r = requests.get('http://www.baidu.com', proxies=proxies, timeout=10, verify=False)
+        r = requests.get('http://www.baidu.com',
+                         proxies=proxies, timeout=10, verify=False)
         if r.status_code == 200:
             return True
     except Exception as e:
         pass
     return False
-

--- a/cli/start.sh
+++ b/cli/start.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-python proxyPool.py webserver &
-python proxyPool.py schedule
+python3 proxyPool.py webserver &
+python3 proxyPool.py schedule

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ click==7.0
 gunicorn==19.9.0
 pymongo
 redis
+bs4
+html5lib
+requests_html
+pysocks


### PR DESCRIPTION
# What I did

This pool kind of mindlessly grab proxies from the internet assuming they are all HTTP proxies, I think it will be better to change the `proxy` format to `proxy_type://proxy_addr:port`, by doing which we can seamlessly support other types of proxy such as `socks4` and `https` as well

`validUsefulProxy()` has also been revamped to support different proxy types

`get_socks` api returns a random socks proxy

Several socks proxy sources were added to `getFreeProxy.py` and enabled in `setting.py`

# Why do we need other types of proxy?

Most HTTP proxies don't allow `CONNECT` method, they can only be used for web browsing.

If you use [proxychains](https://github.com/rofl0r/proxychains-ng), most of the HTTP proxies provided by this pool are not usable. A socks4/5 proxy can easily solve this problem


PS. Considering we generally don't need socks5's UDP proxy, and socks5 can be used as socks4 (to proxy TCP connections), I assume all socks proxies are socks4 in my code