### PR TITLE
[modify] 优化docker镜像体积

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,21 @@
-FROM python:3.6
+FROM python:3.6-alpine
 
 MAINTAINER jhao104 <j_hao104@163.com>
 
 ENV TZ Asia/Shanghai
 
-WORKDIR /usr/src/app
+WORKDIR /app
 
 COPY ./requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple/
+RUN apk add musl-dev gcc libxml2-dev libxslt-dev && \
+    pip install --no-cache-dir -r requirements.txt && \
+    apk del gcc musl-dev
 
 COPY . .
 
 EXPOSE 5010
 
-WORKDIR /usr/src/app/cli
+WORKDIR /app/cli
 
 ENTRYPOINT [ "sh", "start.sh" ]


### PR DESCRIPTION
在使用时发现镜像过大, 将341M的镜像大小优化到了48M左右。利于下载