### PR TITLE
修复2.1.0版本之后的docker-compose构建方式

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,13 @@ version: '2'
 services:
   proxy_pool:
     build: .
+    container_name: proxy_pool
     ports:
       - "5010:5010"
     links:
       - proxy_redis
     environment:
-      db_type: SSDB
-      ssdb_host: proxy_redis
-      ssdb_port: 6379
+      DB_CONN: "redis://@proxy_redis:6379/0"
   proxy_redis:
     image: "redis"
+    container_name: proxy_redis


### PR DESCRIPTION
我发现程序在更新到v2.1.0版本之后环境变量参数改变导致旧的docker-compose.yml文件失效，如果基于docker方式搭建的话会出现无法连接到redis的错误。
我更正了这一部分。现在可以直接通过docker-compose直接构建起master节点上的代码