### PR TITLE
增加显示验证https(区分http 和 https）

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,18 @@ docker run --env DB_CONN=redis://:password@ip:port/db -p 5010:5010 jhao104/proxy
 | api | method | Description | arg|
 | ----| ---- | ---- | ----|
 | / | GET | api介绍 | None |
-| /get | GET | 随机获取一个代理 | None|
-| /get_all | GET | 获取所有代理 |None|
+| /get | GET | 随机获取一个代理(http/https) | None|
+| /get_all | GET | 获取所有代理(http/https) |None|
 | /get_status | GET | 查看代理数量 |None|
 | /delete | GET | 删除代理  |proxy=host:ip|
+| /get_https | GET | 随机获取一个https代理 | None
+| /get_https_all | GET | 获取所有https代理 | None
 
 * 爬虫使用
 
 　　如果要在爬虫代码中使用的话， 可以将此api封装成函数直接使用，例如：
+
+
 
 ```python
 import requests
@@ -143,6 +147,7 @@ def getHtml():
     delete_proxy(proxy)
     return None
 ```
+
 
 ### 扩展代理
 

--- a/api/proxyApi.py
+++ b/api/proxyApi.py
@@ -46,7 +46,9 @@ api_list = {
     # 'refresh': u'refresh proxy pool',
     'get_all': u'get all proxy from proxy pool',
     'delete?proxy=127.0.0.1:8080': u'delete an unable proxy',
-    'get_status': u'proxy number'
+    'get_status': u'proxy number',
+    'get_https': u'get an useful https proxy',
+    'get_all_https': u'get all usefull https proxies'
 }
 
 
@@ -91,10 +93,26 @@ def getStatus():
     status = proxy_handler.getCount()
     return status
 
+@app.route('/get_https/')
+def getHttps():
+    proxy = proxy_handler.get()
+    while(proxy.type != "https"):
+        proxy = proxy_handler.get()
+    return proxy.to_dict if proxy else {"code": 0, "src": "no proxy"}
+
+@app.route('/get_https_all/')
+def getAllHttps():
+    proxyList = proxy_handler.getAll()
+    httpsList = []
+    for proxy in proxyList:
+        #print(proxy,proxy.type,type(proxy.type))
+        if proxy.type == "https":
+            httpsList.append(proxy)
+    return jsonify([_.to_dict for _ in httpsList])
 
 def runFlask():
     if platform.system() == "Windows":
-        app.run(host=conf.serverHost, port=conf.serverPort)
+        app.run(host=conf.serverHost, port=conf.serverPort,debug=conf.debugMode)
     else:
         import gunicorn.app.base
 

--- a/handler/configHandler.py
+++ b/handler/configHandler.py
@@ -60,3 +60,7 @@ class ConfigHandler(withMetaclass(Singleton)):
     @LazyProperty
     def timezone(self):
         return os.getenv("TIMEZONE", getattr(setting, 'TIMEZONE', None))
+
+    @LazyProperty
+    def debugMode(self):
+        return setting.DEBUGMODE

--- a/helper/ishttps.py
+++ b/helper/ishttps.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+-------------------------------------------------
+   File Name：     testIsHttps
+   Description :
+   Author :        nansircroft
+   date：          2021/2/06
+-------------------------------------------------
+   Change Activity:
+                   2020/2/06:
+-------------------------------------------------
+"""
+__author__ = 'nansircroft'
+
+from handler.logHandler import LogHandler
+from handler.proxyHandler import ProxyHandler
+from helper.proxy import Proxy
+import requests
+from requests.exceptions import RequestException
+import threading
+
+class HttpsCheckerThread(threading.Thread):
+    def __init__(self, func, *args):
+        super().__init__()
+        self.func = func
+        self.args = args
+        self.result = 0
+
+    def run(self):
+        self.result = self.func(*self.args)
+
+    def get_result(self):
+        try:
+            return self.result
+        except Exception:
+            return None
+
+class HttpsChecker(object):
+
+    __headers = {
+                'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3',
+                'accept-encoding': 'gzip, deflate, br',
+                'accept-language': 'zh-CN,zh;q=0.9',
+                'Connection': 'keep-alive',
+                'cache-control': 'max-age=0',
+                'sec-fetch-mode': 'navigate',
+                'sec-fetch-site': 'none',
+                'sec-fetch-user': '?1',
+                'upgrade-insecure-requests': '1',
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36'
+            }
+
+    __proxy_handler = ProxyHandler()
+    __log = LogHandler("ishttps-checker")
+
+    @staticmethod
+    def __put_proxy(proxy):
+        HttpsChecker.__proxy_handler.put(proxy)
+
+    @staticmethod
+    def __delete_proxy(proxy):
+        HttpsChecker.__proxy_handler.delete(proxy)
+
+    @staticmethod
+    def __proxy_check(proxy):
+        try:
+            response = requests.get("https://www.baidu.com/", headers=HttpsChecker.__headers, proxies={"https": "https://{}".format(proxy.proxy)},timeout=3)
+            if response.status_code == 200:
+                proxy.type = "https"
+                HttpsChecker.__delete_proxy(proxy)
+                HttpsChecker.__put_proxy(proxy)#(Proxy.createFromJson(json.dumps(proxy)))
+                HttpsChecker.__log.info("Https Check - {} is https".format(proxy.proxy))
+        except RequestException:
+            proxy.type = "http"
+            HttpsChecker.__delete_proxy(proxy)
+            HttpsChecker.__put_proxy(proxy)#(Proxy.createFromJson(json.dumps(proxy)))
+            HttpsChecker.__log.info("Https Check - {} is http".format(proxy.proxy))
+
+    @staticmethod
+    def __proxy_get_all():
+        return HttpsChecker.__proxy_handler.getAll()
+
+
+    @staticmethod
+    def https_check():
+        proxyList = HttpsChecker.__proxy_get_all()
+        HttpsChecker.__log.info("Https Check Start!")
+        threadList = []
+        for proxy in proxyList:
+            t=HttpsCheckerThread(HttpsChecker.__proxy_check,proxy)
+            threadList.append(t)
+            t.start()
+        for t in threadList:
+            t.join()
+        HttpsChecker.__log.info("Https Check Done!")
+
+def runHttpsChecker():
+    HttpsChecker.https_check()
+
+if __name__ == "__main__":
+    #test below
+    HttpsChecker.https_check()
+    # for _ in range(30):
+    #     __proxy_check(__get_proxy())
+    #all = __proxy_get_all()
+    #print(type(__proxy_get_all()[0]['proxy']))

--- a/helper/ishttps.py
+++ b/helper/ishttps.py
@@ -3,14 +3,14 @@
 -------------------------------------------------
    File Name：     testIsHttps
    Description :
-   Author :        nansircroft
+   Author :        nansirc（https://github.com/nansirc）
    date：          2021/2/06
 -------------------------------------------------
    Change Activity:
                    2020/2/06:
 -------------------------------------------------
 """
-__author__ = 'nansircroft'
+__author__ = 'nansirc'
 
 from handler.logHandler import LogHandler
 from handler.proxyHandler import ProxyHandler

--- a/helper/scheduler.py
+++ b/helper/scheduler.py
@@ -19,6 +19,7 @@ from util.six import Queue
 from helper.proxy import Proxy
 from helper.fetch import runFetcher
 from helper.check import runChecker
+from helper.ishttps import runHttpsChecker
 from handler.logHandler import LogHandler
 from handler.proxyHandler import ProxyHandler
 from handler.configHandler import ConfigHandler
@@ -44,13 +45,15 @@ def runProxyCheck():
 
 def runScheduler():
     runProxyFetch()
-
+    runHttpsChecker()
+    
     timezone = ConfigHandler().timezone
     scheduler_log = LogHandler("scheduler")
     scheduler = BlockingScheduler(logger=scheduler_log, timezone=timezone)
 
     scheduler.add_job(runProxyFetch, 'interval', minutes=4, id="proxy_fetch", name="proxy采集")
     scheduler.add_job(runProxyCheck, 'interval', minutes=2, id="proxy_check", name="proxy检查")
+    scheduler.add_job(runHttpsChecker,'interval',minutes=2, id="https_check", name="https检查")
 
     executors = {
         'default': {'type': 'threadpool', 'max_workers': 20},

--- a/proxyPool.py
+++ b/proxyPool.py
@@ -12,7 +12,6 @@
 """
 __author__ = 'JHao'
 
-from helper.ishttps import runHttpsChecker
 import click
 
 from setting import BANNER, VERSION

--- a/proxyPool.py
+++ b/proxyPool.py
@@ -12,6 +12,7 @@
 """
 __author__ = 'JHao'
 
+from helper.ishttps import runHttpsChecker
 import click
 
 from setting import BANNER, VERSION
@@ -41,7 +42,6 @@ def server():
     click.echo("VERSION: %s\n" % VERSION)
     from api.proxyApi import runFlask
     runFlask()
-
 
 if __name__ == '__main__':
     cli()

--- a/setting.py
+++ b/setting.py
@@ -25,7 +25,7 @@ BANNER = r"""
 ****************************************************************
 """
 
-VERSION = "2.1.1"
+VERSION = "2.2.0"
 
 # ############### server config ###############
 HOST = "0.0.0.0"
@@ -37,7 +37,7 @@ PORT = 5010
 # example:
 #      Redis: redis://:password@ip:port/db
 #      Ssdb:  ssdb://:password@ip:port
-DB_CONN = 'redis://:pwd@127.0.0.1:6379/0'
+DB_CONN = 'redis://:@127.0.0.1:6379/0'
 
 # proxy table name
 TABLE_NAME = 'use_proxy'
@@ -76,3 +76,5 @@ MAX_FAIL_COUNT = 0
 # Otherwise it will detect the timezone from the system automatically.
 
 # TIMEZONE = "Asia/Shanghai"
+
+DEBUGMODE = True

--- a/test.py
+++ b/test.py
@@ -15,13 +15,17 @@ __author__ = 'JHao'
 from test import testConfigHandler
 from test import testLogHandler
 from test import testDbClient
+from test import testIsHttps
 
 if __name__ == '__main__':
-    print("ConfigHandler:")
-    testConfigHandler.testConfig()
+   #  print("ConfigHandler:")
+   #  testConfigHandler.testConfig()
 
-    print("LogHandler:")
-    testLogHandler.testLogHandler()
+   #  print("LogHandler:")
+   #  testLogHandler.testLogHandler()
 
-    print("DbClient:")
-    testDbClient.testDbClient()
+   #  print("DbClient:")
+   #  testDbClient.testDbClient()
+
+   print("IsHttps:")
+   testIsHttps.runHttpsChecker()

--- a/test/testIsHttps.py
+++ b/test/testIsHttps.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+-------------------------------------------------
+   File Name：     testIsHttps
+   Description :
+   Author :        nansircroft
+   date：          2021/2/06
+-------------------------------------------------
+   Change Activity:
+                   2020/2/06:
+-------------------------------------------------
+"""
+__author__ = 'nansircroft'
+
+from helper.ishttps import runHttpsChecker
+
+def testIsHttps():
+    runHttpsChecker()
+
+
+
+if __name__ == "__main__":
+    testIsHttps()

--- a/test/testIsHttps.py
+++ b/test/testIsHttps.py
@@ -3,14 +3,14 @@
 -------------------------------------------------
    File Name：     testIsHttps
    Description :
-   Author :        nansircroft
+   Author :        nansirc（https://github.com/nansirc）
    date：          2021/2/06
 -------------------------------------------------
    Change Activity:
                    2020/2/06:
 -------------------------------------------------
 """
-__author__ = 'nansircroft'
+__author__ = 'nansirc'
 
 from helper.ishttps import runHttpsChecker
 


### PR DESCRIPTION
### 有一些网站需要https代理才能顺利访问，或者如果在系统或浏览器上用http代理是不能直接访问https协议的网址的，显示验证和获取https代理可以帮助解决这个问题。
### 新增
1. 增加通过https代理验证一个ip是否为https类型
2. 对调度器适当修改，使其自动调度显示验证https
3. 增加获取https代理ip的web api：/get_https & /get_https_all
4. 一些单元测试