### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 APScheduler==3.2.0
-werkzeug==0.15.3
+werkzeug==0.15.5
 Flask==1.0
 requests==2.20.0
 PyExecJS==1.5.1


### PR DESCRIPTION
Werkzeug 0.15.3 contains a bug about dependency, update to 0.15.5 can fix it.

detail:
https://stackoverflow.com/questions/60140174/basic-flask-app-not-running-typeerror-required-field-type-ignores-missing-fr