### PR TITLE
Integer conversion 將讀入環境變數適當的轉換為整數

### DIFF
--- a/handler/configHandler.py
+++ b/handler/configHandler.py
@@ -55,23 +55,23 @@ class ConfigHandler(withMetaclass(Singleton)):
 
     @LazyProperty
     def verifyTimeout(self):
-        return os.getenv("VERIFY_TIMEOUT", setting.VERIFY_TIMEOUT)
+        return int(os.getenv("VERIFY_TIMEOUT", setting.VERIFY_TIMEOUT))
 
     # @LazyProperty
     # def proxyCheckCount(self):
-    #     return os.getenv("PROXY_CHECK_COUNT", setting.PROXY_CHECK_COUNT)
+    #     return int(os.getenv("PROXY_CHECK_COUNT", setting.PROXY_CHECK_COUNT))
 
     @LazyProperty
     def maxFailCount(self):
-        return os.getenv("MAX_FAIL_COUNT", setting.MAX_FAIL_COUNT)
+        return int(os.getenv("MAX_FAIL_COUNT", setting.MAX_FAIL_COUNT))
 
     # @LazyProperty
     # def maxFailRate(self):
-    #     return os.getenv("MAX_FAIL_RATE", setting.MAX_FAIL_RATE)
+    #     return int(os.getenv("MAX_FAIL_RATE", setting.MAX_FAIL_RATE))
 
     @LazyProperty
     def poolSizeMin(self):
-        return os.getenv("POOL_SIZE_MIN", setting.POOL_SIZE_MIN)
+        return int(os.getenv("POOL_SIZE_MIN", setting.POOL_SIZE_MIN))
 
     @LazyProperty
     def timezone(self):


### PR DESCRIPTION
os.getenv讀取進來的值固定為str, 會造成程式出錯 
比如設定環境變數
MAX_FAIL_COUNT: 3
會造成 helper/check.py:114 產生錯誤