### PR TITLE
修复代理验证问题

### DIFF
--- a/helper/validator.py
+++ b/helper/validator.py
@@ -13,7 +13,8 @@
 __author__ = 'JHao'
 
 from re import findall
-from requests import head
+from requests import head, request
+import requests
 from util.six import withMetaclass
 from util.singleton import Singleton
 from handler.configHandler import ConfigHandler
@@ -62,8 +63,9 @@ def httpTimeOutValidator(proxy):
     proxies = {"http": "http://{proxy}".format(proxy=proxy), "https": "https://{proxy}".format(proxy=proxy)}
 
     try:
-        r = head(conf.httpUrl, headers=HEADER, proxies=proxies, timeout=conf.verifyTimeout)
-        return True if r.status_code == 200 else False
+        # r = head(conf.httpUrl, headers=HEADER, proxies=proxies, timeout=conf.verifyTimeout)
+        r = requests.get(conf.httpUrl, headers=HEADER, proxies=proxies, timeout=conf.verifyTimeout)
+        return True if ("origin" in r.text) else False
     except Exception as e:
         return False
 
@@ -74,8 +76,9 @@ def httpsTimeOutValidator(proxy):
 
     proxies = {"http": "http://{proxy}".format(proxy=proxy), "https": "https://{proxy}".format(proxy=proxy)}
     try:
-        r = head(conf.httpsUrl, headers=HEADER, proxies=proxies, timeout=conf.verifyTimeout, verify=False)
-        return True if r.status_code == 200 else False
+        # r = head(conf.httpsUrl, headers=HEADER, proxies=proxies, timeout=conf.verifyTimeout, verify=False)
+        r = requests.get(conf.httpsUrl, headers=HEADER, proxies=proxies, timeout=conf.verifyTimeout, verify=False)
+        return True if "origin" in r.text else False
     except Exception as e:
         return False
 

--- a/setting.py
+++ b/setting.py
@@ -59,9 +59,9 @@ PROXY_FETCHER = [
 
 # ############# proxy validator #################
 # 代理验证目标网站
-HTTP_URL = "http://httpbin.org"
+HTTP_URL = "http://httpbin.org/ip"
 
-HTTPS_URL = "https://www.qq.com"
+HTTPS_URL = "https://httpbin.org/ip"
 
 # 代理验证时超时时间
 VERIFY_TIMEOUT = 10


### PR DESCRIPTION
在使用时，有些 代理IP 需要用户验证，或者有些代理已经失效但是返回 `status_code 200`，所以这类代理的验证就会通过`checker`的检查。

本次修改：
1. 将 `http` 和 `https` 的代理验证网址改为 `http://httpbin.org/ip` 和 `https://httpbin.org/ip`。
2. 将 `checker` 的检查修改为检测 `get` 之后的内容。即检测 `origin` 字符串的存在。