### PR TITLE
扩展了/get api，使其支持参数region从而支持获取指定地区的代理

### DIFF
--- a/api/proxyApi.py
+++ b/api/proxyApi.py
@@ -42,7 +42,7 @@ class JsonResponse(Response):
 app.response_class = JsonResponse
 
 api_list = [
-    {"url": "/get", "params": "type: ''https'|''", "desc": "get a proxy"},
+    {"url": "/get", "params": "type: 'https'|'', region: '代理地区, 中文'", "desc": "get a proxy"},
     {"url": "/pop", "params": "", "desc": "get and delete a proxy"},
     {"url": "/delete", "params": "proxy: 'e.g. 127.0.0.1:8080'", "desc": "delete an unable proxy"},
     {"url": "/all", "params": "type: ''https'|''", "desc": "get all proxy from proxy pool"},
@@ -59,7 +59,8 @@ def index():
 @app.route('/get/')
 def get():
     https = request.args.get("type", "").lower() == 'https'
-    proxy = proxy_handler.get(https)
+    region = request.args.get("region", "").lower()
+    proxy = proxy_handler.get(https, region)
     return proxy.to_dict if proxy else {"code": 0, "src": "no proxy"}
 
 

--- a/db/dbClient.py
+++ b/db/dbClient.py
@@ -86,8 +86,8 @@ class DbClient(withMetaclass(Singleton)):
                                                                                      password=self.db_pwd,
                                                                                      db=self.db_name)
 
-    def get(self, https, **kwargs):
-        return self.client.get(https, **kwargs)
+    def get(self, https, region, **kwargs):
+        return self.client.get(https, region, **kwargs)
 
     def put(self, key, **kwargs):
         return self.client.put(key, **kwargs)

--- a/db/redisClient.py
+++ b/db/redisClient.py
@@ -47,7 +47,7 @@ class RedisClient(object):
                                                                    socket_timeout=5,
                                                                    **kwargs))
 
-    def get(self, https):
+    def get(self, https, region):
         """
         返回一个代理
         :return:
@@ -55,6 +55,12 @@ class RedisClient(object):
         if https:
             items = self.__conn.hvals(self.name)
             proxies = list(filter(lambda x: json.loads(x).get("https"), items))
+            if region != '':
+                proxies = list(filter(lambda x: region in json.loads(x).get("region"), iter(proxies)))
+            return choice(proxies) if proxies else None
+        elif region != '':
+            items = self.__conn.hvals(self.name)
+            proxies = list(filter(lambda x: region in json.loads(x).get("region"), items))
             return choice(proxies) if proxies else None
         else:
             proxies = self.__conn.hkeys(self.name)

--- a/handler/proxyHandler.py
+++ b/handler/proxyHandler.py
@@ -26,14 +26,15 @@ class ProxyHandler(object):
         self.db = DbClient(self.conf.dbConn)
         self.db.changeTable(self.conf.tableName)
 
-    def get(self, https=False):
+    def get(self, https=False, region=''):
         """
         return a proxy
         Args:
             https: True/False
+            region:
         Returns:
         """
-        proxy = self.db.get(https)
+        proxy = self.db.get(https, region)
         return Proxy.createFromJson(proxy) if proxy else None
 
     def pop(self, https):

--- a/helper/check.py
+++ b/helper/check.py
@@ -13,6 +13,9 @@
 """
 __author__ = 'JHao'
 
+import requests
+import json
+
 from util.six import Empty
 from threading import Thread
 from datetime import datetime
@@ -40,6 +43,7 @@ class DoValidator(object):
         proxy.check_count += 1
         proxy.last_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         proxy.last_status = True if http_r else False
+        proxy._region = cls.region_get(proxy.proxy)
         if http_r:
             if proxy.fail_count > 0:
                 proxy.fail_count -= 1
@@ -68,6 +72,14 @@ class DoValidator(object):
             if not func(proxy):
                 return False
         return True
+
+    @classmethod
+    def region_get(cls, proxy):
+        try:
+            r = requests.get(url='https://searchplugin.csdn.net/api/v1/ip/get', params={'ip': proxy.split(':')[0]})
+            return json.loads(r.text)['data']['address']
+        except:
+            return '未知或请求失败'
 
 
 class _ThreadChecker(Thread):


### PR DESCRIPTION
前提：我提交的上一个pr #691 
扩展了/get api，使其支持参数region从而支持获取指定地区的代理
e.g.
http://ip:5010/get?region=中国
返回
{
  "anonymous": "",
  "check_count": 27,
  "fail_count": 0,
  "https": false,
  "last_status": true,
  "last_time": "2022-08-13 22:36:27",
  "proxy": "112.250.110.172:9091",
  "region": "中国 山东 泰安 联通",
  "source": "freeProxy06"
}

http://ip:5010/get?region=云南
返回
{
  "anonymous": "",
  "check_count": 1,
  "fail_count": 0,
  "https": false,
  "last_status": true,
  "last_time": "2022-08-13 22:37:11",
  "proxy": "39.130.150.42:80",
  "region": "中国 云南 昆明 移动",
  "source": "freeProxy07"
}