### PR TITLE
添加匿名度检查, 扩展/get

### DIFF
--- a/api/proxyApi.py
+++ b/api/proxyApi.py
@@ -42,7 +42,7 @@ class JsonResponse(Response):
 app.response_class = JsonResponse
 
 api_list = [
-    {"url": "/get", "params": "type: ''https'|''", "desc": "get a proxy"},
+    {"url": "/get", "params": "type: 'https'|'', region: '代理地区, 中文'", "desc": "get a proxy"},
     {"url": "/pop", "params": "", "desc": "get and delete a proxy"},
     {"url": "/delete", "params": "proxy: 'e.g. 127.0.0.1:8080'", "desc": "delete an unable proxy"},
     {"url": "/all", "params": "type: ''https'|''", "desc": "get all proxy from proxy pool"},
@@ -59,7 +59,8 @@ def index():
 @app.route('/get/')
 def get():
     https = request.args.get("type", "").lower() == 'https'
-    proxy = proxy_handler.get(https)
+    region = request.args.get("region", "").lower()
+    proxy = proxy_handler.get(https, region)
     return proxy.to_dict if proxy else {"code": 0, "src": "no proxy"}
 
 

--- a/api/proxyApi.py
+++ b/api/proxyApi.py
@@ -42,7 +42,7 @@ class JsonResponse(Response):
 app.response_class = JsonResponse
 
 api_list = [
-    {"url": "/get", "params": "type: 'https'|'', region: '代理地区, 中文'", "desc": "get a proxy"},
+    {"url": "/get", "params": "type: 'https'|'', region: '代理地区, 中文', anonymous: '任意: -1, '", "desc": "get a proxy"},
     {"url": "/pop", "params": "", "desc": "get and delete a proxy"},
     {"url": "/delete", "params": "proxy: 'e.g. 127.0.0.1:8080'", "desc": "delete an unable proxy"},
     {"url": "/all", "params": "type: ''https'|''", "desc": "get all proxy from proxy pool"},
@@ -60,7 +60,11 @@ def index():
 def get():
     https = request.args.get("type", "").lower() == 'https'
     region = request.args.get("region", "").lower()
-    proxy = proxy_handler.get(https, region)
+    try:
+        anonymous = int(request.args.get("anonymous", '').lower())
+    except:
+        anonymous = -1
+    proxy = proxy_handler.get(https, region, anonymous)
     return proxy.to_dict if proxy else {"code": 0, "src": "no proxy"}
 
 

--- a/db/dbClient.py
+++ b/db/dbClient.py
@@ -86,8 +86,8 @@ class DbClient(withMetaclass(Singleton)):
                                                                                      password=self.db_pwd,
                                                                                      db=self.db_name)
 
-    def get(self, https, **kwargs):
-        return self.client.get(https, **kwargs)
+    def get(self, https, region, **kwargs):
+        return self.client.get(https, region, **kwargs)
 
     def put(self, key, **kwargs):
         return self.client.put(key, **kwargs)

--- a/db/dbClient.py
+++ b/db/dbClient.py
@@ -86,8 +86,8 @@ class DbClient(withMetaclass(Singleton)):
                                                                                      password=self.db_pwd,
                                                                                      db=self.db_name)
 
-    def get(self, https, region, **kwargs):
-        return self.client.get(https, region, **kwargs)
+    def get(self, https, region, anonymous, **kwargs):
+        return self.client.get(https, region, anonymous, **kwargs)
 
     def put(self, key, **kwargs):
         return self.client.put(key, **kwargs)

--- a/db/redisClient.py
+++ b/db/redisClient.py
@@ -47,7 +47,7 @@ class RedisClient(object):
                                                                    socket_timeout=5,
                                                                    **kwargs))
 
-    def get(self, https):
+    def get(self, https, region):
         """
         返回一个代理
         :return:
@@ -55,6 +55,12 @@ class RedisClient(object):
         if https:
             items = self.__conn.hvals(self.name)
             proxies = list(filter(lambda x: json.loads(x).get("https"), items))
+            if region != '':
+                proxies = list(filter(lambda x: region in json.loads(x).get("region"), iter(proxies)))
+            return choice(proxies) if proxies else None
+        elif region != '':
+            items = self.__conn.hvals(self.name)
+            proxies = list(filter(lambda x: region in json.loads(x).get("region"), items))
             return choice(proxies) if proxies else None
         else:
             proxies = self.__conn.hkeys(self.name)

--- a/db/redisClient.py
+++ b/db/redisClient.py
@@ -47,25 +47,35 @@ class RedisClient(object):
                                                                    socket_timeout=5,
                                                                    **kwargs))
 
-    def get(self, https, region):
+    def get(self, https, region, anonymous):
         """
         返回一个代理
         :return:
         """
+        items = self.__conn.hvals(self.name)
+        proxies = list(items)
         if https:
-            items = self.__conn.hvals(self.name)
             proxies = list(filter(lambda x: json.loads(x).get("https"), items))
-            if region != '':
-                proxies = list(filter(lambda x: region in json.loads(x).get("region"), iter(proxies)))
-            return choice(proxies) if proxies else None
-        elif region != '':
-            items = self.__conn.hvals(self.name)
-            proxies = list(filter(lambda x: region in json.loads(x).get("region"), items))
-            return choice(proxies) if proxies else None
-        else:
-            proxies = self.__conn.hkeys(self.name)
-            proxy = choice(proxies) if proxies else None
-            return self.__conn.hget(self.name, proxy) if proxy else None
+        if region != '':
+            proxies = list(filter(lambda x: region in json.loads(x).get("region"), iter(proxies)))
+        if anonymous != -1:
+            proxies = list(filter(lambda x: json.loads(x).get("anonymous") == anonymous, iter(proxies)))
+        return choice(proxies) if proxies else None
+
+        # if https:
+        #     items = self.__conn.hvals(self.name)
+        #     proxies = list(filter(lambda x: json.loads(x).get("https"), items))
+        #     if region != '':
+        #         proxies = list(filter(lambda x: region in json.loads(x).get("region"), iter(proxies)))
+        #     return choice(proxies) if proxies else None
+        # elif region != '':
+        #     items = self.__conn.hvals(self.name)
+        #     proxies = list(filter(lambda x: region in json.loads(x).get("region"), items))
+        #     return choice(proxies) if proxies else None
+        # else:
+        #     proxies = self.__conn.hkeys(self.name)
+        #     proxy = choice(proxies) if proxies else None
+        #     return self.__conn.hget(self.name, proxy) if proxy else None
 
     def put(self, proxy_obj):
         """

--- a/handler/proxyHandler.py
+++ b/handler/proxyHandler.py
@@ -26,14 +26,15 @@ class ProxyHandler(object):
         self.db = DbClient(self.conf.dbConn)
         self.db.changeTable(self.conf.tableName)
 
-    def get(self, https=False):
+    def get(self, https=False, region=''):
         """
         return a proxy
         Args:
             https: True/False
+            region:
         Returns:
         """
-        proxy = self.db.get(https)
+        proxy = self.db.get(https, region)
         return Proxy.createFromJson(proxy) if proxy else None
 
     def pop(self, https):

--- a/handler/proxyHandler.py
+++ b/handler/proxyHandler.py
@@ -26,15 +26,16 @@ class ProxyHandler(object):
         self.db = DbClient(self.conf.dbConn)
         self.db.changeTable(self.conf.tableName)
 
-    def get(self, https=False, region=''):
+    def get(self, https=False, region='', anonymous=-1):
         """
         return a proxy
         Args:
             https: True/False
             region:
+            anonymous:
         Returns:
         """
-        proxy = self.db.get(https, region)
+        proxy = self.db.get(https, region, anonymous)
         return Proxy.createFromJson(proxy) if proxy else None
 
     def pop(self, https):

--- a/helper/check.py
+++ b/helper/check.py
@@ -13,6 +13,9 @@
 """
 __author__ = 'JHao'
 
+import requests
+import json
+
 from util.six import Empty
 from threading import Thread
 from datetime import datetime
@@ -40,6 +43,7 @@ class DoValidator(object):
         proxy.check_count += 1
         proxy.last_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         proxy.last_status = True if http_r else False
+        proxy._region = cls.region_get(proxy.proxy)
         if http_r:
             if proxy.fail_count > 0:
                 proxy.fail_count -= 1
@@ -68,6 +72,14 @@ class DoValidator(object):
             if not func(proxy):
                 return False
         return True
+
+    @classmethod
+    def region_get(cls, proxy):
+        try:
+            r = requests.get(url='https://searchplugin.csdn.net/api/v1/ip/get', params={'ip': proxy.split(':')[0]})
+            return json.loads(r.text)['data']['address']
+        except:
+            return '未知或请求失败'
 
 
 class _ThreadChecker(Thread):

--- a/helper/check.py
+++ b/helper/check.py
@@ -44,6 +44,7 @@ class DoValidator(object):
         proxy.last_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         proxy.last_status = True if http_r else False
         proxy._region = cls.region_get(proxy.proxy)
+        proxy._anonymous = cls.anonymousValidator(proxy.proxy, proxy.https)
         if http_r:
             if proxy.fail_count > 0:
                 proxy.fail_count -= 1
@@ -80,6 +81,27 @@ class DoValidator(object):
             return json.loads(r.text)['data']['address']
         except:
             return '未知或请求失败'
+
+    @classmethod
+    def anonymousValidator(cls, proxy, https):
+        if https:
+            url = 'https://httpbin.org/get'
+            proxy = {'https': proxy}
+        else:
+            url = 'http://httpbin.org/get'
+            proxy = {'http': proxy}
+
+        r = requests.get(url, proxies=proxy)
+        r = json.loads(r.text)
+        try:
+            if ',' in r.get('origin'):
+                return 0
+            elif r.get('headers').get('Proxy-connecttion', False):
+                return 1
+            else:
+                return 2
+        except:
+            return -1
 
 
 class _ThreadChecker(Thread):


### PR DESCRIPTION
添加了匿名度校验(anonymous不空啦)
扩展了/get api,支持参数anonymous从而支持获取指定匿名度的ip
anonymous值说明
后端: -1获取失败, 0透明, 1匿名, 2高匿
前端: -1任意匿名度的代理, 空:同-1, 其他同后端
e.g.
/get/?anonymous=2
返回:
{
  "anonymous": 2,
  "check_count": 21,
  "fail_count": 0,
  "https": false,
  "last_status": true,
  "last_time": "2022-08-14 21:27:14",
  "proxy": "120.237.144.57:9091",
  "region": "中国 广东 佛山 移动",
  "source": "freeProxy06/freeProxy03"
}

