### PR TITLE
fix(sec): upgrade gunicorn to 20.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ werkzeug==0.15.5
 Flask==1.0
 requests==2.20.0
 click==7.0
-gunicorn==19.9.0
+gunicorn==20.0.1
 lxml
 redis


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in gunicorn 19.9.0
- [MPS-2022-14935](https://www.oscs1024.com/hd/MPS-2022-14935)


### What did I do？
Upgrade gunicorn from 19.9.0 to 20.0.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS