### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 APScheduler==3.2.0
 werkzeug==0.15.5
-Flask==1.0
+Flask==2.2.2
 requests==2.20.0
 click==7.0
 gunicorn==19.9.0


### PR DESCRIPTION
Fixed the error “cannot import name 'Markup' from 'jinja2'” by upgrading version of Flask