### PR TITLE
增加代理来源并支持按地区获取代理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/
 docs/_build
 *.pyc
+*.pyc.*
+__pycache__/
 *.log
 .tox
 /SPEC.md

--- a/api/proxyApi.py
+++ b/api/proxyApi.py
@@ -17,6 +17,7 @@
 __author__ = 'JHao'
 
 import platform
+from random import shuffle
 from werkzeug.wrappers import Response
 from flask import Flask, jsonify, request
 
@@ -42,13 +43,39 @@ class JsonResponse(Response):
 app.response_class = JsonResponse
 
 api_list = [
-    {"url": "/get", "params": "type: ''https'|''", "desc": "get a proxy"},
-    {"url": "/pop", "params": "", "desc": "get and delete a proxy"},
+    {"url": "/get", "params": "type: ''https'|'', count: '1', region: 'e.g. CN'", "desc": "get proxy"},
+    {"url": "/pop", "params": "type: ''https'|'', region: 'e.g. CN'", "desc": "get and delete a proxy"},
     {"url": "/delete", "params": "proxy: 'e.g. 127.0.0.1:8080'", "desc": "delete an unable proxy"},
-    {"url": "/all", "params": "type: ''https'|''", "desc": "get all proxy from proxy pool"},
-    {"url": "/count", "params": "", "desc": "return proxy count"}
+    {"url": "/all", "params": "type: ''https'|'', region: 'e.g. CN'", "desc": "get all proxy from proxy pool"},
+    {"url": "/count", "params": "region: 'e.g. CN'", "desc": "return proxy count"}
     # 'refresh': 'refresh proxy pool',
 ]
+
+
+def _get_https_arg():
+    return request.args.get("type", "").lower() == 'https'
+
+
+def _get_region_arg():
+    return request.args.get("region", "").strip()
+
+
+def _get_count_arg(default=1):
+    try:
+        return max(int(request.args.get("count", default)), 1)
+    except (TypeError, ValueError):
+        return default
+
+
+def _filter_region(proxies, region):
+    if not region:
+        return proxies
+    region = region.lower()
+    return [proxy for proxy in proxies if str(proxy.region).lower() == region]
+
+
+def _get_filtered_proxies(https=False, region=""):
+    return _filter_region(proxy_handler.getAll(https), region)
 
 
 @app.route('/')
@@ -58,15 +85,33 @@ def index():
 
 @app.route('/get/')
 def get():
-    https = request.args.get("type", "").lower() == 'https'
-    proxy = proxy_handler.get(https)
-    return proxy.to_dict if proxy else {"code": 0, "src": "no proxy"}
+    https = _get_https_arg()
+    region = _get_region_arg()
+    count = _get_count_arg()
+    if count == 1 and not region:
+        proxy = proxy_handler.get(https)
+        return proxy.to_dict if proxy else {"code": 0, "src": "no proxy"}
+
+    proxies = _get_filtered_proxies(https, region)
+    if not proxies:
+        return {"code": 0, "src": "no proxy"}
+    shuffle(proxies)
+    result = [proxy.to_dict for proxy in proxies[:count]]
+    return result[0] if count == 1 else jsonify(result)
 
 
 @app.route('/pop/')
 def pop():
-    https = request.args.get("type", "").lower() == 'https'
-    proxy = proxy_handler.pop(https)
+    https = _get_https_arg()
+    region = _get_region_arg()
+    if region:
+        proxies = _get_filtered_proxies(https, region)
+        shuffle(proxies)
+        proxy = proxies[0] if proxies else None
+        if proxy:
+            proxy_handler.delete(proxy)
+    else:
+        proxy = proxy_handler.pop(https)
     return proxy.to_dict if proxy else {"code": 0, "src": "no proxy"}
 
 
@@ -78,8 +123,9 @@ def refresh():
 
 @app.route('/all/')
 def getAll():
-    https = request.args.get("type", "").lower() == 'https'
-    proxies = proxy_handler.getAll(https)
+    https = _get_https_arg()
+    region = _get_region_arg()
+    proxies = _get_filtered_proxies(https, region)
     return jsonify([_.to_dict for _ in proxies])
 
 
@@ -92,7 +138,7 @@ def delete():
 
 @app.route('/count/')
 def getCount():
-    proxies = proxy_handler.getAll()
+    proxies = _get_filtered_proxies(region=_get_region_arg())
     http_type_dict = {}
     source_dict = {}
     for proxy in proxies:

--- a/fetcher/proxyFetcher.py
+++ b/fetcher/proxyFetcher.py
@@ -16,6 +16,8 @@ import re
 import json
 from time import sleep
 
+from lxml import etree
+
 from util.webRequest import WebRequest
 
 
@@ -25,11 +27,74 @@ class ProxyFetcher(object):
     """
 
     @staticmethod
+    def _parse_proxies_from_text(text):
+        if not text:
+            return []
+        proxy_pattern = re.compile(r'(?<![\d.])(\d{1,3}(?:\.\d{1,3}){3})(?:\s*:\s*|\s+)(\d{2,5})(?!\d)')
+        return ["%s:%s" % proxy for proxy in proxy_pattern.findall(text)]
+
+    @staticmethod
+    def _parse_proxies_from_json(data):
+        proxies = []
+        if isinstance(data, dict):
+            proxy = data.get("proxy") or data.get("addr") or data.get("address")
+            if proxy:
+                proxies.extend(ProxyFetcher._parse_proxies_from_text(str(proxy)))
+
+            ip = data.get("ip") or data.get("host") or data.get("server")
+            port = data.get("port")
+            if ip and port:
+                proxies.append("%s:%s" % (ip, port))
+
+            parsed_keys = {"proxy", "addr", "address", "ip", "host", "server", "port"}
+            for key, value in data.items():
+                if key in parsed_keys:
+                    continue
+                proxies.extend(ProxyFetcher._parse_proxies_from_json(value))
+        elif isinstance(data, list):
+            for item in data:
+                proxies.extend(ProxyFetcher._parse_proxies_from_json(item))
+        elif isinstance(data, str):
+            proxies.extend(ProxyFetcher._parse_proxies_from_text(data))
+        return proxies
+
+    @staticmethod
+    def _parse_proxies_from_tree(tree):
+        proxies = []
+        if tree is None:
+            return proxies
+        for tr in tree.xpath("//tr"):
+            cells = [" ".join(td.xpath(".//text()")).strip() for td in tr.xpath("./td")]
+            if len(cells) < 2:
+                continue
+            ip = ""
+            port = ""
+            for cell in cells:
+                ip_match = re.search(r'\d{1,3}(?:\.\d{1,3}){3}', cell)
+                port_match = re.search(r'\b\d{2,5}\b', cell)
+                if ip_match and not ip:
+                    ip = ip_match.group()
+                    continue
+                if port_match and not port:
+                    port = port_match.group()
+            if ip and port:
+                proxies.append("%s:%s" % (ip, port))
+        return proxies
+
+    @staticmethod
+    def _yield_unique_proxies(proxies):
+        seen = set()
+        for proxy in proxies:
+            if proxy not in seen:
+                seen.add(proxy)
+                yield proxy
+
+    @staticmethod
     def freeProxy01():
         """
         站大爷 https://www.zdaye.com/dayProxy.html
         """
-        start_url = "https://www.zdaye.com/dayProxy.html"
+        start_url = "https://www.zdaye.com/free/"
         html_tree = WebRequest().get(start_url, verify=False).tree
         latest_page_time = html_tree.xpath("//span[@class='thread_time_info']/text()")[0].strip()
         from datetime import datetime
@@ -132,12 +197,50 @@ class ProxyFetcher(object):
     @staticmethod
     def freeProxy08():
         """ 小幻代理 """
-        urls = ['https://ip.ihuan.me/address/5Lit5Zu9.html']
-        for url in urls:
-            r = WebRequest().get(url, timeout=10)
-            proxies = re.findall(r'>\s*?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s*?</a></td><td>(\d+)</td>', r.text)
-            for proxy in proxies:
-                yield ":".join(proxy)
+        request = WebRequest()
+        ti_url = "https://ip.ihuan.me/ti.html"
+        tqdl_url = "https://ip.ihuan.me/tqdl.html"
+        ti_resp = request.get(ti_url, timeout=10, verify=False)
+        form_data = {}
+        if ti_resp.tree is not None:
+            for input_tag in ti_resp.tree.xpath("//form//input[@name]"):
+                name = "".join(input_tag.xpath("./@name")).strip()
+                value = "".join(input_tag.xpath("./@value")).strip()
+                if name:
+                    form_data[name] = value
+
+        key = form_data.get("key")
+        if not key:
+            key_match = re.search(r'name=["\']key["\'][^>]*value=["\']([^"\']+)', ti_resp.text)
+            if not key_match:
+                key_match = re.search(r'key["\']?\s*[:=]\s*["\']([0-9a-f]{16,})', ti_resp.text)
+            key = key_match.group(1) if key_match else ""
+
+        if not key:
+            return
+
+        header = {
+            "Origin": "https://ip.ihuan.me",
+            "Referer": ti_url,
+        }
+        data = form_data.copy()
+        data.update({
+            "num": "2000",
+            "port": "",
+            "kill_port": "",
+            "address": "",
+            "kill_address": "",
+            "anonymity": "",
+            "type": "",
+            "post": "",
+            "sort": "1",
+            "key": key,
+        })
+        r = request.post(tqdl_url, header=header, data=data, timeout=10, verify=False)
+        proxies = ProxyFetcher._parse_proxies_from_tree(r.tree)
+        proxies.extend(ProxyFetcher._parse_proxies_from_text(r.text))
+        for proxy in ProxyFetcher._yield_unique_proxies(proxies):
+            yield proxy
 
     @staticmethod
     def freeProxy09(page_count=1):
@@ -180,6 +283,55 @@ class ProxyFetcher(object):
             port = "".join(item.xpath("./ul/li[2]/text()")).strip()
             if ip and port:
                 yield "%s:%s" % (ip, port)
+
+    @staticmethod
+    def freeProxy13():
+        """ FreeVPNNode 中国代理 https://cn.freevpnnode.com/free-proxy-for-china/ """
+        # url = "https://cn.freevpnnode.com/free-proxy-for-china/"
+        url = "https://cn.freevpnnode.com/free-proxy/"
+        r = WebRequest().get(url, timeout=5, retry_time=1, verify=False)
+        proxies = ProxyFetcher._parse_proxies_from_tree(r.tree)
+        proxies.extend(ProxyFetcher._parse_proxies_from_text(r.text))
+        for proxy in ProxyFetcher._yield_unique_proxies(proxies):
+            yield proxy
+
+    @staticmethod
+    def freeProxy14():
+        """ SCDN 代理接口 """
+        # url = "https://proxy.scdn.io/get_proxies.php?protocol=&country=%E4%B8%AD%E5%9B%BD&per_page=100&page=1"
+        url = "https://proxy.scdn.io/get_proxies.php?protocol=&country=&per_page=100&page=1"
+        r = WebRequest().get(url, timeout=5, retry_time=1, verify=False)
+        try:
+            data = r.json
+            proxies = []
+            table_html = data.get("table_html") if isinstance(data, dict) else ""
+            if table_html:
+                tree = etree.HTML("<table>%s</table>" % table_html)
+                proxies.extend(ProxyFetcher._parse_proxies_from_tree(tree))
+
+            if not proxies:
+                proxies = ProxyFetcher._parse_proxies_from_json(data)
+            if not proxies:
+                proxies = ProxyFetcher._parse_proxies_from_text(r.text)
+            for proxy in ProxyFetcher._yield_unique_proxies(proxies):
+                yield proxy
+        except Exception as e:
+            print(e)
+
+    @staticmethod
+    def freeProxy15():
+        """ Geonode Free Proxy 中国代理 https://geonode.com/free-proxy-list/ """
+        # url = "https://proxylist.geonode.com/api/proxy-list?limit=500&page=1&sort_by=lastChecked&sort_type=desc&country=CN"
+        url = "https://proxylist.geonode.com/api/proxy-list?limit=500&page=1&sort_by=lastChecked&sort_type=desc"
+        r = WebRequest().get(url, timeout=5, retry_time=1, verify=False)
+        try:
+            proxies = ProxyFetcher._parse_proxies_from_json(r.json)
+            if not proxies:
+                proxies = ProxyFetcher._parse_proxies_from_text(r.text)
+            for proxy in ProxyFetcher._yield_unique_proxies(proxies):
+                yield proxy
+        except Exception as e:
+            print(e)
 
     # @staticmethod
     # def wallProxy01():

--- a/helper/check.py
+++ b/helper/check.py
@@ -79,9 +79,9 @@ class DoValidator(object):
     @classmethod
     def regionGetter(cls, proxy):
         try:
-            url = 'https://api.ip.sb/geoip/%s' % proxy.proxy.split(':')[0]
+            url = 'https://opendata.baidu.com/api.php?query=%s&co=&resource_id=6006&oe=utf8' % proxy.proxy.split(':')[0]
             r = WebRequest().get(url=url, retry_time=1, timeout=2).json
-            return r.get('country_code')
+            return r.data[0].location
         except:
             return 'error'
 

--- a/helper/check.py
+++ b/helper/check.py
@@ -79,9 +79,9 @@ class DoValidator(object):
     @classmethod
     def regionGetter(cls, proxy):
         try:
-            url = 'https://searchplugin.csdn.net/api/v1/ip/get?ip=%s' % proxy.proxy.split(':')[0]
+            url = 'https://api.ip.sb/geoip/%s' % proxy.proxy.split(':')[0]
             r = WebRequest().get(url=url, retry_time=1, timeout=2).json
-            return r['data']['address']
+            return r.get('country_code')
         except:
             return 'error'
 

--- a/setting.py
+++ b/setting.py
@@ -57,6 +57,9 @@ PROXY_FETCHER = [
     "freeProxy10",
     "freeProxy11",
     "freeProxy12",
+    "freeProxy13",
+    "freeProxy14",
+    "freeProxy15",
 ]
 
 # ############# proxy validator #################

--- a/util/six.py
+++ b/util/six.py
@@ -30,7 +30,10 @@ else:
     from urlparse import urlparse
 
 if PY3:
-    from imp import reload as reload_six
+    try:
+        from importlib import reload as reload_six
+    except ImportError:
+        from imp import reload as reload_six
 else:
     reload_six = reload
 

--- a/util/webRequest.py
+++ b/util/webRequest.py
@@ -86,8 +86,38 @@ class WebRequest(object):
                 self.log.info("retry %s second after" % retry_interval)
                 time.sleep(retry_interval)
 
+    def post(self, url, header=None, retry_time=3, retry_interval=5, timeout=5, *args, **kwargs):
+        """
+        post method
+        :param url: target url
+        :param header: headers
+        :param retry_time: retry time
+        :param retry_interval: retry interval
+        :param timeout: network timeout
+        :return:
+        """
+        headers = self.header
+        if header and isinstance(header, dict):
+            headers.update(header)
+        while True:
+            try:
+                self.response = requests.post(url, headers=headers, timeout=timeout, *args, **kwargs)
+                return self
+            except Exception as e:
+                self.log.error("requests: %s error: %s" % (url, str(e)))
+                retry_time -= 1
+                if retry_time <= 0:
+                    resp = Response()
+                    resp.status_code = 200
+                    self.response = resp
+                    return self
+                self.log.info("retry %s second after" % retry_interval)
+                time.sleep(retry_interval)
+
     @property
     def tree(self):
+        if not self.response.content:
+            return None
         return etree.HTML(self.response.content)
 
     @property
@@ -101,4 +131,3 @@ class WebRequest(object):
         except Exception as e:
             self.log.error(str(e))
             return {}
-


### PR DESCRIPTION
新增 3 个代理抓取源：FreeVPNNode、scdnio、geonode
增强代理解析能力，支持从文本、HTML 表格、JSON 中提取代理
/get 支持 count 批量获取代理，并支持 region 地区筛选
/pop、/all、/count 增加 region 筛选
WebRequest 新增 post() 方法，并避免空响应解析 HTML 时报错
地区识别接口从 CSDN 改为 api.ip.sb，返回 country_code
.gitignore 增加 __pycache__/ 和 *.pyc.*