### PR TITLE
fix: 升级Docker基础镜像至python:3.10-alpine修复构建失败

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM python:3.6-alpine
+FROM python:3.10-alpine
 
-MAINTAINER jhao104 <j_hao104@163.com>
+LABEL maintainer="jhao104 <j_hao104@163.com>"
 
 WORKDIR /app
 
 COPY ./requirements.txt .
-
-# apk repository
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
 
 # timezone and init process
 RUN apk add -U tzdata tini && \


### PR DESCRIPTION
Python 3.6已停止维护，Alpine官方源不再支持，导致apk add失败。
同时将废弃的MAINTAINER指令替换为LABEL maintainer。